### PR TITLE
[202412][FRR] Integrate bug fixes related to nexthop handling

### DIFF
--- a/src/sonic-frr/patch/0128-bgpd-add-total-path-count-for-bgp-net-in-json-output.patch
+++ b/src/sonic-frr/patch/0128-bgpd-add-total-path-count-for-bgp-net-in-json-output.patch
@@ -1,0 +1,35 @@
+From d4ee69224946e0568f61e2bda2f6a8b90abba612 Mon Sep 17 00:00:00 2001
+From: Soumya Roy <souroy@nvidia.com>
+Date: Thu, 1 May 2025 06:12:40 +0000
+Subject: [PATCH] bgpd: add total path count for bgp net in json output
+
+Currently only vty output shows total path count for a
+BGP net. This fix add that information in josn output too.
+
+Signed-off-by: Soumya Roy <souroy@nvidia.com>
+---
+ bgpd/bgp_route.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/bgpd/bgp_route.c b/bgpd/bgp_route.c
+index 9f71809e3..f1232ad71 100644
+--- a/bgpd/bgp_route.c
++++ b/bgpd/bgp_route.c
+@@ -12670,6 +12670,14 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
+ 				vty_out(vty, "  Not advertised to any peer");
+ 			vty_out(vty, "\n");
+ 		}
++
++		if (json) {
++			if (incremental_print) {
++				vty_out(vty, "\"pathCount\": %d", count);
++				vty_out(vty, ",");
++			} else
++				json_object_int_add(json, "pathCount", count);
++		}
+ 	}
+ }
+ 
+-- 
+2.39.5
+

--- a/src/sonic-frr/patch/0129-zebra-Prevent-a-kernel-route-from-being-there-when-a.patch
+++ b/src/sonic-frr/patch/0129-zebra-Prevent-a-kernel-route-from-being-there-when-a.patch
@@ -1,0 +1,82 @@
+From adb4ec31ded49581fb0782b0df728af29352840f Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Mon, 14 Oct 2024 11:25:32 -0400
+Subject: [PATCH] zebra: Prevent a kernel route from being there when a
+ connected should
+
+There exists a series of events where a kernel route is learned
+first( that happens to be exactly what a connected route should be )
+and FRR ends up with both a kernel route and a connected route,
+leaving us in a very strange spot.  This code change just mirrors
+the existing code of if there is a connected route drop the kernel
+route.  Here we just do the reverse, if we have a kernel route
+already and a connected should be created, remove the kernel and
+keep the connected.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ zebra/connected.c | 37 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 37 insertions(+)
+
+diff --git a/zebra/connected.c b/zebra/connected.c
+index 404f892f6..5c72de7ab 100644
+--- a/zebra/connected.c
++++ b/zebra/connected.c
+@@ -176,6 +176,40 @@ static void connected_update(struct interface *ifp, struct connected *ifc)
+ 		connected_announce(ifp, ifc);
+ }
+ 
++/*
++ * This function goes through and handles the deletion of a kernel route that happened
++ * to be the exact same as the connected route, so that the connected route wins.
++ * This can happen during processing if we happen to receive events in a slightly
++ * unexpected order.  This is similiar to code in the other direction where if we
++ * have a kernel route don't install it if it perfectly matches a connected route.
++ */
++static void connected_remove_kernel_for_connected(afi_t afi, safi_t safi, struct zebra_vrf *zvrf,
++						  struct prefix *p, struct nexthop *nh)
++{
++	struct route_node *rn;
++	struct route_entry *re;
++	rib_dest_t *dest;
++	struct route_table *table = zebra_vrf_table(afi, SAFI_UNICAST, zvrf->vrf->vrf_id);
++
++	rn = route_node_match(table, p);
++	if (!rn)
++		return;
++
++	if (!prefix_same(&rn->p, p))
++		return;
++
++	dest = rib_dest_from_rnode(rn);
++	if (!dest || !dest->selected_fib)
++		return;
++
++	re = dest->selected_fib;
++	if (re->type != ZEBRA_ROUTE_KERNEL)
++		return;
++
++	rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_KERNEL, 0, 0, p, NULL, nh, 0,
++		   zvrf->table_id, 0, 0, false);
++}
++
+ /* Called from if_up(). */
+ void connected_up(struct interface *ifp, struct connected *ifc)
+ {
+@@ -283,10 +317,13 @@ void connected_up(struct interface *ifp, struct connected *ifc)
+ 	}
+ 
+ 	if (!CHECK_FLAG(ifc->flags, ZEBRA_IFA_NOPREFIXROUTE)) {
++		connected_remove_kernel_for_connected(afi, SAFI_UNICAST, zvrf, &p, &nh);
++
+ 		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id,
+ 			ZEBRA_ROUTE_CONNECT, 0, flags, &p, NULL, &nh, 0,
+ 			zvrf->table_id, metric, 0, 0, 0, false);
+ 
++		connected_remove_kernel_for_connected(afi, SAFI_MULTICAST, zvrf, &p, &nh);
+ 		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
+ 			ZEBRA_ROUTE_CONNECT, 0, flags, &p, NULL, &nh, 0,
+ 			zvrf->table_id, metric, 0, 0, 0, false);
+-- 
+2.39.5
+

--- a/src/sonic-frr/patch/0130-zebra-show-nexthop-count-in-nexthop-group-command.patch
+++ b/src/sonic-frr/patch/0130-zebra-show-nexthop-count-in-nexthop-group-command.patch
@@ -1,0 +1,79 @@
+From 3e152003ca456b00409e93c287b25e68d05cadce Mon Sep 17 00:00:00 2001
+From: Krishnasamy <krishnasamyr@nvidia.com>
+Date: Tue, 6 May 2025 06:49:52 +0000
+Subject: [PATCH] zebra: show nexthop count in nexthop-group command
+
+Show the nexthops count in an NHG
+
+Signed-off-by: Krishnasamy <krishnasamyr@nvidia.com>
+---
+ lib/nexthop_group.c | 2 +-
+ lib/nexthop_group.h | 1 +
+ zebra/zebra_vty.c   | 5 +++++
+ 3 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/lib/nexthop_group.c b/lib/nexthop_group.c
+index cb1ebb5d0..fb023f375 100644
+--- a/lib/nexthop_group.c
++++ b/lib/nexthop_group.c
+@@ -81,7 +81,7 @@ uint16_t nexthop_group_nexthop_num(const struct nexthop_group *nhg)
+ 	return num;
+ }
+ 
+-static uint16_t nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg)
++uint16_t nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg)
+ {
+ 	struct nexthop *nhop;
+ 	uint16_t num = 0;
+diff --git a/lib/nexthop_group.h b/lib/nexthop_group.h
+index 910329941..3891ff88a 100644
+--- a/lib/nexthop_group.h
++++ b/lib/nexthop_group.h
+@@ -153,6 +153,7 @@ extern uint16_t nexthop_group_nexthop_num(const struct nexthop_group *nhg);
+ extern uint16_t nexthop_group_active_nexthop_num(const struct nexthop_group *nhg);
+ 
+ extern bool nexthop_group_has_label(const struct nexthop_group *nhg);
++extern uint16_t nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg);
+ 
+ #ifdef __cplusplus
+ }
+diff --git a/zebra/zebra_vty.c b/zebra/zebra_vty.c
+index 5fb643184..79f479437 100644
+--- a/zebra/zebra_vty.c
++++ b/zebra/zebra_vty.c
+@@ -1184,6 +1184,7 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
+ 	json_object *json = NULL;
+ 	json_object *json_backup_nexthop_array = NULL;
+ 	json_object *json_backup_nexthops = NULL;
++	uint16_t nexthop_count = 0;
+ 
+ 
+ 	uptime2str(nhe->uptime, up_str, sizeof(up_str));
+@@ -1191,6 +1192,8 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
+ 	if (json_nhe_hdr)
+ 		json = json_object_new_object();
+ 
++	nexthop_count = nexthop_group_nexthop_num_no_recurse(&nhe->nhg);
++
+ 	if (json) {
+ 		json_object_string_add(json, "type",
+ 				       zebra_route_string(nhe->type));
+@@ -1204,6 +1207,7 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
+ 		json_object_string_add(json, "uptime", up_str);
+ 		json_object_string_add(json, "vrf",
+ 				       vrf_id_to_name(nhe->vrf_id));
++		json_object_int_add(json, "nexthopCount", nexthop_count);
+ 
+ 	} else {
+ 		vty_out(vty, "ID: %u (%s)\n", nhe->id,
+@@ -1218,6 +1222,7 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
+ 
+ 		vty_out(vty, "     Uptime: %s\n", up_str);
+ 		vty_out(vty, "     VRF: %s\n", vrf_id_to_name(nhe->vrf_id));
++		vty_out(vty, "     Nexthop Count: %u\n", nexthop_count);
+ 	}
+ 
+ 	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_VALID)) {
+-- 
+2.39.5
+

--- a/src/sonic-frr/patch/0131-lib-Add-nexthop_same_no_ifindex-comparison-function.patch
+++ b/src/sonic-frr/patch/0131-lib-Add-nexthop_same_no_ifindex-comparison-function.patch
@@ -1,0 +1,112 @@
+From fec4e109e3d90bf150306f1dec372471bad66706 Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Thu, 1 May 2025 12:21:30 -0400
+Subject: [PATCH] lib: Add nexthop_same_no_ifindex comparison function
+
+Add a nexthop_same_no_ifindex comparison function to
+allow nexthops to be compared without looking at the
+outgoing ifindex.  This is because sometimes it is
+not possible to resolve a nh to a ifindex when
+zebra receives it and we need the ability to compare
+them then.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ lib/nexthop.c | 28 ++++++++++++++++++++++------
+ lib/nexthop.h |  1 +
+ 2 files changed, 23 insertions(+), 6 deletions(-)
+ 
+diff --git a/lib/nexthop.c b/lib/nexthop.c
+index dfa3c3a55c..d83f63f96c 100644
+--- a/lib/nexthop.c
++++ b/lib/nexthop.c
+@@ -139,7 +139,7 @@ static int _nexthop_source_cmp(const struct nexthop *nh1,
+ }
+ 
+ static int _nexthop_cmp_no_labels(const struct nexthop *next1,
+-				  const struct nexthop *next2, bool use_weight)
++				  const struct nexthop *next2, bool use_weight, bool use_ifindex)
+ {
+ 	int ret = 0;
+ 
+@@ -175,6 +175,8 @@ static int _nexthop_cmp_no_labels(const struct nexthop *next1,
+ 		ret = _nexthop_gateway_cmp(next1, next2);
+ 		if (ret != 0)
+ 			return ret;
++		if (!use_ifindex)
++			break;
+ 		fallthrough;
+ 	case NEXTHOP_TYPE_IFINDEX:
+ 		if (next1->ifindex < next2->ifindex)
+@@ -230,11 +232,11 @@ done:
+ }
+ 
+ static int nexthop_cmp_internal(const struct nexthop *next1,
+-				const struct nexthop *next2, bool use_weight)
++				const struct nexthop *next2, bool use_weight, bool use_ifindex)
+ {
+ 	int ret = 0;
+ 
+-	ret = _nexthop_cmp_no_labels(next1, next2, use_weight);
++	ret = _nexthop_cmp_no_labels(next1, next2, use_weight, use_ifindex);
+ 	if (ret != 0)
+ 		return ret;
+ 
+@@ -249,13 +251,13 @@ static int nexthop_cmp_internal(const struct nexthop *next1,
+ 
+ int nexthop_cmp(const struct nexthop *next1, const struct nexthop *next2)
+ {
+-	return nexthop_cmp_internal(next1, next2, true);
++	return nexthop_cmp_internal(next1, next2, true, true);
+ }
+ 
+ int nexthop_cmp_no_weight(const struct nexthop *next1,
+ 			  const struct nexthop *next2)
+ {
+-	return nexthop_cmp_internal(next1, next2, false);
++	return nexthop_cmp_internal(next1, next2, false, true);
+ }
+ 
+ /*
+@@ -426,6 +428,20 @@ void nexthops_free(struct nexthop *nexthop)
+ 	}
+ }
+ 
++bool nexthop_same_no_ifindex(const struct nexthop *nh1, const struct nexthop *nh2)
++{
++	if (nh1 && !nh2)
++		return false;
++
++	if (!nh1 && nh2)
++		return false;
++
++	if (nh1 == nh2)
++		return true;
++
++	return nexthop_cmp_internal(nh1, nh2, true, false);
++}
++
+ bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2)
+ {
+ 	if (nh1 && !nh2)
+@@ -455,7 +471,7 @@ bool nexthop_same_no_labels(const struct nexthop *nh1,
+ 	if (nh1 == nh2)
+ 		return true;
+ 
+-	if (_nexthop_cmp_no_labels(nh1, nh2, true) != 0)
++	if (_nexthop_cmp_no_labels(nh1, nh2, true, true) != 0)
+ 		return false;
+ 
+ 	return true;
+diff --git a/lib/nexthop.h b/lib/nexthop.h
+index c8492f91f7..4715c2215c 100644
+--- a/lib/nexthop.h
++++ b/lib/nexthop.h
+@@ -209,6 +209,7 @@ uint32_t nexthop_hash(const struct nexthop *nexthop);
+ uint32_t nexthop_hash_quick(const struct nexthop *nexthop);
+ 
+ extern bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2);
++extern bool nexthop_same_no_ifindex(const struct nexthop *nh1, const struct nexthop *nh2);
+ extern bool nexthop_same_no_labels(const struct nexthop *nh1,
+ 				   const struct nexthop *nh2);
+ extern int nexthop_cmp(const struct nexthop *nh1, const struct nexthop *nh2);

--- a/src/sonic-frr/patch/0132-zebra-Allow-nhg-s-to-be-reused-when-multiple-interfa.patch
+++ b/src/sonic-frr/patch/0132-zebra-Allow-nhg-s-to-be-reused-when-multiple-interfa.patch
@@ -1,0 +1,90 @@
+From ee73ade5a7a66c25d2efbe29a37273e24628079a Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Thu, 24 Apr 2025 14:45:14 -0400
+Subject: [PATCH] zebra: Allow nhg's to be reused when multiple interfaces are
+ going amuck
+
+Currently if there are multiple interfaces going down it is possible
+to have a ships in the night situation with trying to reuse a nhg.
+
+Imagine that you have a route w/ 4 way ecmp
+  nexthop A interface a
+  nexthop B interface b
+  nexthop C interface c
+  nexthop D interface d
+
+Suppose interface a goes down, zebra receives this data
+marks singleton nexthop A down and then recurses up the
+tree to the 4 way ecmp and sets nexthop A as inactive.
+Zebra then will notify the upper level protocol.
+
+The upper level protocol will refigure the route and send
+it down with 3 way ecmp.  At the same time if interface
+b goes down and zebra handles that interface down event
+before the new route installation, then when
+zebra_nhg_rib_compare_old_nhe is called it will not
+match the old and new ones up as that the old will be:
+
+  nexthop A  <inactive>
+  nexthop B  <inactive>
+  nexthop C
+  nexthop D
+
+New will be:
+
+   nexthop B  <inactive>
+   nexthop C
+   nexthop D
+
+Currently zebra_nhg_nexthop_compare on the old skips all
+the inactive but it never skips the nexthops at are inactive
+on the new.
+
+Modify the code to allow the new nhop to be skipped if it
+is the same nexthop being looked at as the old and it
+is not active as well.  This allows zebra to choose
+the same nhg in the above case to continue working.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ zebra/zebra_nhg.c | 20 +++++++++++++++++---
+ 1 file changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/zebra/zebra_nhg.c b/zebra/zebra_nhg.c
+index 51ae6493a..99750b3db 100644
+--- a/zebra/zebra_nhg.c
++++ b/zebra/zebra_nhg.c
+@@ -2933,13 +2933,27 @@ static bool zebra_nhg_nexthop_compare(const struct nexthop *nhop,
+ 
+ 	while (nhop && old_nhop) {
+ 		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+-			zlog_debug("%s: %pRN Comparing %pNHvv(%u) to old: %pNHvv(%u)",
+-				   __func__, rn, nhop, nhop->flags, old_nhop,
+-				   old_nhop->flags);
++			zlog_debug("%s: %pRN Comparing %pNHvv(%u) ACTIVE: %d to old: %pNHvv(%u) ACTIVE: %d nexthop same: %d",
++				   __func__, rn, nhop, nhop->flags,
++				   CHECK_FLAG(nhop->flags, NEXTHOP_FLAG_ACTIVE), old_nhop,
++				   old_nhop->flags, CHECK_FLAG(old_nhop->flags, NEXTHOP_FLAG_ACTIVE),
++				   nexthop_same_no_ifindex(nhop, old_nhop));
+ 		if (!CHECK_FLAG(old_nhop->flags, NEXTHOP_FLAG_ACTIVE)) {
+ 			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+ 				zlog_debug("%s: %pRN Old is not active going to the next one",
+ 					   __func__, rn);
++
++			/*
++			 * If the new nexthop is not active and the old nexthop is also not active,
++			 * then we know that we can skip both the old and new nexthops.
++			 */
++			if (!CHECK_FLAG(nhop->flags, NEXTHOP_FLAG_ACTIVE) &&
++			    nexthop_same_no_ifindex(nhop, old_nhop)) {
++				if (IS_ZEBRA_DEBUG_NHG_DETAIL)
++					zlog_debug("%s: %pRN new is not active going to the next one",
++						   __func__, rn);
++				nhop = nhop->next;
++			}
+ 			old_nhop = old_nhop->next;
+ 			continue;
+ 		}
+-- 
+2.39.5
+

--- a/src/sonic-frr/patch/0133-zebra-Prevent-active-setting-if-interface-is-not-ope.patch
+++ b/src/sonic-frr/patch/0133-zebra-Prevent-active-setting-if-interface-is-not-ope.patch
@@ -1,0 +1,75 @@
+From b201aa82309c03508d15dcbcb059a803a954134c Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Thu, 1 May 2025 10:09:47 -0400
+Subject: [PATCH] zebra: Prevent active setting if interface is not operative
+
+Currently Installing nhg's has two paths for installation:
+a) A route comes in with a new nhg that will be selected.
+Zebra will check that the nexthops are good and signal
+that the route is ready for installation.  This in turn
+causes the nexthop to be installed first before the route
+installation.  This nexthop group installation then looks
+at each singleton and attempts to install those as well.
+This is a way to get routes installed quickly into the system
+if needed.
+
+b) A interface has an event that causes a nexthop group
+to change.  This will cause singletons to be handled appropriately
+and then once those are handled and installed the handler
+for the nexthop install success will walk the nexthop groups
+that use that nexthop and reinstalls them as well.
+
+Unfortunately both A and B are currently funneled through
+the same function.
+
+Now for the problem that is being seen:
+
+If you have a NHG A that uses NHG B/C/D nexthops.  Imagine
+that the B and C interfaces are down.  The NHG A will have
+B( inactive/!installed), C(inactive/!installed), D(active/installed)
+
+Now if interface B comes up, this will cause nexthop B to be
+reinstalled.  After B comes back up we will call a nexthop
+group reinstallation for A.  Since it is using the same
+functionality to reinstall, it looks at all it's singletons
+and sees that C is not installed and it was marking C as active,
+even though the interface is down) and attempting to reinstall it.
+
+Unfortunately if interface C happens to be up in the kernel, but
+not yet in zebra, you end up with nh C being installed and we
+mark the nh C as valid and installed.  Then when interface
+C actually comes up, it sees that the nhg C is up and does
+nothing.  Leaving the nhg's in a broken state.
+
+Modify the active setting to not set a singleton NH as
+active if the interface is not operational.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ zebra/zebra_nhg.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/zebra/zebra_nhg.c b/zebra/zebra_nhg.c
+index 99750b3db..7ca6700bf 100644
+--- a/zebra/zebra_nhg.c
++++ b/zebra/zebra_nhg.c
+@@ -2768,8 +2768,14 @@ static bool zebra_nhg_set_valid_if_active(struct nhg_hash_entry *nhe)
+ 	}
+ 
+ 	/* should be fully resolved singleton at this point */
+-	if (CHECK_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_ACTIVE))
+-		valid = true;
++	if (CHECK_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_ACTIVE)) {
++		struct interface *ifp = if_lookup_by_index(nhe->nhg.nexthop->ifindex, nhe->vrf_id);
++
++		if (!ifp || !if_is_operative(ifp))
++			valid = false;
++		else
++			valid = true;
++	}
+ 
+ done:
+ 	if (valid)
+-- 
+2.39.5
+

--- a/src/sonic-frr/patch/0134-zebra-Add-nexthop-group-id-to-route-dump.patch
+++ b/src/sonic-frr/patch/0134-zebra-Add-nexthop-group-id-to-route-dump.patch
@@ -1,0 +1,29 @@
+From 1005576d20c296355492c3253952c2d1b303048f Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Wed, 7 May 2025 11:34:16 -0400
+Subject: [PATCH] zebra: Add nexthop group id to route dump
+
+The `show ip zebra route dump" command is not
+displaying the nexthop group id number.  Add that
+in.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ zebra/zebra_vty.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/zebra/zebra_vty.c b/zebra/zebra_vty.c
+index 79f479437..c8a8460a4 100644
+--- a/zebra/zebra_vty.c
++++ b/zebra/zebra_vty.c
+@@ -2237,6 +2237,7 @@ static void show_ip_route_dump_vty(struct vty *vty, struct route_table *table)
+ 					 tm.tm_hour);
+ 
+ 			vty_out(vty, "   status: %u\n", re->status);
++			vty_out(vty, "   nexthop_group_id: %u\n", re->nhe->id);
+ 			vty_out(vty, "   nexthop_num: %u\n",
+ 				nexthop_group_nexthop_num(&(re->nhe->nhg)));
+ 			vty_out(vty, "   nexthop_active_num: %u\n",
+-- 
+2.39.5
+

--- a/src/sonic-frr/patch/0135-zebra-Display-interface-name-not-ifindex-in-nh-dump.patch
+++ b/src/sonic-frr/patch/0135-zebra-Display-interface-name-not-ifindex-in-nh-dump.patch
@@ -1,0 +1,83 @@
+From dd9f4cef797e94e0856516bff22dfb8aa791459d Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Wed, 7 May 2025 11:42:02 -0400
+Subject: [PATCH] zebra: Display interface name not ifindex in nh dump
+
+When dumping nexthop data, display the interface name
+as well.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ zebra/zebra_rib.c | 43 ++++++++++++++-----------------------------
+ 1 file changed, 14 insertions(+), 29 deletions(-)
+
+diff --git a/zebra/zebra_rib.c b/zebra/zebra_rib.c
+index 81f19bea9..84c4e2404 100644
+--- a/zebra/zebra_rib.c
++++ b/zebra/zebra_rib.c
+@@ -4225,12 +4225,13 @@ void route_entry_dump_nh(const struct route_entry *re,
+ 	struct interface *ifp;
+ 	struct vrf *vrf = vrf_lookup_by_id(nexthop->vrf_id);
+ 
++	ifp = if_lookup_by_index(nexthop->ifindex, nexthop->vrf_id);
++
+ 	switch (nexthop->type) {
+ 	case NEXTHOP_TYPE_BLACKHOLE:
+ 		snprintf(nhname, sizeof(nhname), "Blackhole");
+ 		break;
+ 	case NEXTHOP_TYPE_IFINDEX:
+-		ifp = if_lookup_by_index(nexthop->ifindex, nexthop->vrf_id);
+ 		snprintf(nhname, sizeof(nhname), "%s",
+ 			 ifp ? ifp->name : "Unknown");
+ 		break;
+@@ -4268,35 +4269,19 @@ void route_entry_dump_nh(const struct route_entry *re,
+ 	if (nexthop->weight)
+ 		snprintf(wgt_str, sizeof(wgt_str), "wgt %d,", nexthop->weight);
+ 
+-	zlog_debug("%s: %s %s[%u] %svrf %s(%u) %s%s with flags %s%s%s%s%s%s%s%s%s",
+-		   straddr, (nexthop->rparent ? "  NH" : "NH"), nhname,
+-		   nexthop->ifindex, label_str, vrf ? vrf->name : "Unknown",
+-		   nexthop->vrf_id,
++	zlog_debug("%s: %s %s[%s:%d] %svrf %s(%u) %s%s with flags %s%s%s%s%s%s%s%s%s", straddr,
++		   (nexthop->rparent ? "  NH" : "NH"), nhname, ifp ? ifp->name : "Unknown",
++		   nexthop->ifindex, label_str, vrf ? vrf->name : "Unknown", nexthop->vrf_id,
+ 		   wgt_str, backup_str,
+-		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE)
+-		    ? "ACTIVE "
+-		    : ""),
+-		   (CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED)
+-		    ? "FIB "
+-		    : ""),
+-		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE)
+-		    ? "RECURSIVE "
+-		    : ""),
+-		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK)
+-		    ? "ONLINK "
+-		    : ""),
+-		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE)
+-		    ? "DUPLICATE "
+-		    : ""),
+-		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RNH_FILTERED)
+-		    ? "FILTERED " : ""),
+-		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_HAS_BACKUP)
+-		    ? "BACKUP " : ""),
+-		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_SRTE)
+-		    ? "SRTE " : ""),
+-		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_EVPN)
+-		    ? "EVPN " : ""));
+-
++		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE) ? "ACTIVE " : ""),
++		   (CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED) ? "FIB " : ""),
++		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE) ? "RECURSIVE " : ""),
++		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK) ? "ONLINK " : ""),
++		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE) ? "DUPLICATE " : ""),
++		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RNH_FILTERED) ? "FILTERED " : ""),
++		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_HAS_BACKUP) ? "BACKUP " : ""),
++		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_SRTE) ? "SRTE " : ""),
++		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_EVPN) ? "EVPN " : ""));
+ }
+ 
+ /* This function dumps the contents of a given RE entry into
+-- 
+2.39.5
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -107,3 +107,11 @@
 0125-bgpd-Fix-holdtime-not-working-properly-when-busy.patch
 0126-bgpd-ensure-that-bgp_generate_updgrp_packets-shares-.patch
 0127-zebra-show-command-to-display-metaq-info.patch
+0128-bgpd-add-total-path-count-for-bgp-net-in-json-output.patch
+0129-zebra-Prevent-a-kernel-route-from-being-there-when-a.patch
+0130-zebra-show-nexthop-count-in-nexthop-group-command.patch
+0131-lib-Add-nexthop_same_no_ifindex-comparison-function.patch
+0132-zebra-Allow-nhg-s-to-be-reused-when-multiple-interfa.patch
+0133-zebra-Prevent-active-setting-if-interface-is-not-ope.patch
+0134-zebra-Add-nexthop-group-id-to-route-dump.patch
+0135-zebra-Display-interface-name-not-ifindex-in-nh-dump.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Integrate bug fixes that were found during 512 BGP testing

#### How I did it

| Patch | Upstream Commit |
|-------|----------------|
| 0128-bgpd-add-total-path-count-for-bgp-net-in-json-output.patch | [be3c6d3](https://github.com/FRRouting/frr/commit/be3c6d3) |
| 0129-zebra-Prevent-a-kernel-route-from-being-there-when-a.patch | [74e2519](https://github.com/FRRouting/frr/commit/74e2519)  |
| 0130-zebra-show-nexthop-count-in-nexthop-group-command.patch | [da5703e](https://github.com/FRRouting/frr/commit/da5703e)  |
| 0131-lib-Add-nexthop_same_no_ifindex-comparison-function.patch | [66f552c](https://github.com/FRRouting/frr/commit/66f552c)  |
| 0132-zebra-Allow-nhg-s-to-be-reused-when-multiple-interfa.patch | [46044a4](https://github.com/FRRouting/frr/commit/46044a4)  |
| 0133-zebra-Prevent-active-setting-if-interface-is-not-ope.patch | [e5f4675](https://github.com/FRRouting/frr/commit/e5f4675)  |
| 0134-zebra-Add-nexthop-group-id-to-route-dump.patch | [b732ad2](https://github.com/FRRouting/frr/commit/b732ad2)  |
| 0135-zebra-Display-interface-name-not-ifindex-in-nh-dump.patch | [c891cd2](https://github.com/FRRouting/frr/commit/c891cd2)  |

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

